### PR TITLE
Update baking message after scheduled action runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ jobs:
         delay-hours: 48
 ```
 
+## Example:
+
+### Pull request baking start
+![image](https://user-images.githubusercontent.com/2754967/226928503-4cd6c95f-80fe-4a33-8eeb-37147e18cd29.png)
+
+### Update while baking
+![image](https://user-images.githubusercontent.com/2754967/226928759-1074a2e0-4da9-4655-8706-ea052ec9392e.png)
+
+### Baking completed
+![Bake time / Baking pull request... (pull_request) Successful in 5s — The bake time delay has passe](https://user-images.githubusercontent.com/2754967/226927082-66ddea37-476a-4e9e-bc4a-53129ee6156f.png)
+
+
+
 # Changelog
 
 ## Unreleased

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ jobs:
 
 # Changelog
 
+## Unreleased
+- Baking pull requests will be updated to 'pending' with a message about how time remains. 
+
 ## v2
 - Combined into a single step where the trigger determines the behavior
 - Stopped using write operations during the 'pull_request' trigger, by default no write permissions are allowed [[link]](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
 
 # Changelog
 
-## Unreleased
+## v3
 - Baking pull requests will be updated with a message about how time remains. 
 
 ## v2

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ jobs:
 ## Example:
 
 ### Pull request baking start
-![image](https://user-images.githubusercontent.com/2754967/226928503-4cd6c95f-80fe-4a33-8eeb-37147e18cd29.png)
+![Bake time / Baking pull request... (pull_request)](https://user-images.githubusercontent.com/2754967/226928503-4cd6c95f-80fe-4a33-8eeb-37147e18cd29.png)
 
 ### Update while baking
-![image](https://user-images.githubusercontent.com/2754967/226928759-1074a2e0-4da9-4655-8706-ea052ec9392e.png)
+![Bake time / Baking pull request... (pull_request) Failing after 3s — 2 hours remain.](https://user-images.githubusercontent.com/2754967/226933188-383f284b-2cb7-4204-ba21-e17475e31a6d.png)
 
 ### Baking completed
 ![Bake time / Baking pull request... (pull_request) Successful in 5s — The bake time delay has passe](https://user-images.githubusercontent.com/2754967/226927082-66ddea37-476a-4e9e-bc4a-53129ee6156f.png)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
 # Changelog
 
 ## Unreleased
-- Baking pull requests will be updated to 'pending' with a message about how time remains. 
+- Baking pull requests will be updated with a message about how time remains. 
 
 ## v2
 - Combined into a single step where the trigger determines the behavior

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     name: "Baking pull request..."
     runs-on: ubuntu-latest
     steps:
-    - uses: peternied/bake-time@v2
+    - uses: peternied/bake-time@v3
       with:
         check-name: "Baking pull request..."
         delay-hours: 48

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
               repo: context.repo.repo,
               check_run_id: bakeTimeCheckRun.id,
               status: 'in_progress',
-              conclusion: null,
+              conclusion: 'action_required',
               output: {
                 title: `Still baking, least ${timeRemaining.toFixed(2)} hours remaining.`,
                 summary: 'This check will pass once the delay is over.'

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
               status: 'in_progress', // This value cannot be modified once completed, leaving it in if GitHub's APIs support it in the future
               conclusion: 'action_required',
               output: {
-                title: `Still baking, least ${timeRemaining.toFixed(2)} hours remaining.`,
+                title: `Baking >${timeRemaining.toFixed(2)} hours remain.`,
                 summary: 'This check will pass once the delay is over.'
               }
             });

--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
               repo: context.repo.repo,
               check_run_id: bakeTimeCheckRun.id,
               status: 'in_progress',
+              conclusion: null,
               output: {
                 title: `Still baking, least ${timeRemaining.toFixed(2)} hours remaining.`,
                 summary: 'This check will pass once the delay is over.'

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               check_run_id: bakeTimeCheckRun.id,
-              status: 'in_progress',
+              status: 'in_progress', // This value cannot be modified once completed, leaving it in if GitHub's APIs support it in the future
               conclusion: 'action_required',
               output: {
                 title: `Still baking, least ${timeRemaining.toFixed(2)} hours remaining.`,

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,12 @@ runs:
               console.log(`Found ${run.id} named ${run.name} with status ${run.status} for PR #${pr.number}.`)
             }
             continue;
-          } 
+          }
+
+          if (bakeTimeCheckRun.conclusion === "success") {
+            console.log(`PR #${pr.number} has been marked as completed.`);
+            continue;
+          }
 
           // Check if the pull request has not been updated in the specified delay
           if (now - updatedAt >= delayMilliseconds) {
@@ -74,6 +79,20 @@ runs:
           } else {
             // Logging for pull requests that are still waiting
             const timeRemaining = (delayMilliseconds - (now - updatedAt)) / (millisInAnHour);
-            console.log(`PR #${pr.number} still needs to wait for ${timeRemaining.toFixed(2)} hours before the delay is over.`);
+            console.log(`Updating pending status check for PR #${pr.number}.`);
+
+            const { data: checkUpdate } = await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: bakeTimeCheckRun.id,
+              status: 'in_progress',
+              output: {
+                title: `Still baking, least ${timeRemaining.toFixed(2)} hours remaining.`,
+                summary: 'This check will pass once the delay is over.'
+              }
+            });
+
+            console.log(`PR #${pr.number} needs to wait for ${timeRemaining.toFixed(2)} hours before the delay is over.`);
+            console.log(`Detailed check update message ${JSON.stringify(checkUpdate, undefined, 3)}`);
           }
         }

--- a/action.yml
+++ b/action.yml
@@ -87,11 +87,7 @@ runs:
               repo: context.repo.repo,
               check_run_id: bakeTimeCheckRun.id,
               status: 'in_progress', // This value cannot be modified once completed, leaving it in if GitHub's APIs support it in the future
-              conclusion: 'neutral',
-              annotations: [{
-                annotation_level: 'notice',
-                message: updateMessage,
-              }],
+              conclusion: 'failure',
               output: {
                 title: updateMessage,
                 summary: 'This check will pass once the delay is over.'

--- a/action.yml
+++ b/action.yml
@@ -81,14 +81,19 @@ runs:
             const timeRemaining = (delayMilliseconds - (now - updatedAt)) / (millisInAnHour);
             console.log(`Updating pending status check for PR #${pr.number}.`);
 
+            const updateMessage = `${Math.max(timeRemaining.toFixed(0),1)} hours remain.`;
             const { data: checkUpdate } = await github.rest.checks.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               check_run_id: bakeTimeCheckRun.id,
               status: 'in_progress', // This value cannot be modified once completed, leaving it in if GitHub's APIs support it in the future
-              conclusion: 'action_required',
+              conclusion: 'neutral',
+              annotations: [{
+                annotation_level: 'notice',
+                message: updateMessage,
+              }],
               output: {
-                title: `Baking >${timeRemaining.toFixed(2)} hours remain.`,
+                title: updateMessage,
                 summary: 'This check will pass once the delay is over.'
               }
             });


### PR DESCRIPTION
### Description
Update baking message after scheduled action runs.

- `X hours remain.` message in the check, always shows at least 1 hour.
- Added UI previews in Readme.
- Checks already marked successful are not updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
