### PR TITLE
Fix incorrect timestamp evaluation with `ignore-non-push-updates` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ inputs:
     default: 24
     required: false
   ignore-non-push-updates:
-    description: Controls if the bake timer uses the last update to the PR like approvals or the just the last push to calculate the remaining time
+    description: Controls if the bake timer uses the last update to the PR like approvals or the just the date of the merge commit GitHub creates to calculate the remaining time
     default: "false"
     required: false
   check-name:

--- a/action.yml
+++ b/action.yml
@@ -43,12 +43,31 @@ runs:
           repo: context.repo.repo,
           state: 'open',
         });
+        
+        // fetch repo events only once
+        pushEvents = [];
+        if ('${{ inputs.ignore-non-push-updates }}' === 'true') {
+            const { data: repoEvents } = await github.rest.activity.listRepoEvents({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            pushEvents = repoEvents.filter(event => event.type === 'PushEvent');
+        }
 
         const now = new Date();
         for (const pr of pullRequests) {
           modificationTime = pr.updated_at;
-          if ('${{ inputs.ignore-non-push-updates }}' == 'true') {
-            modificationTime = pr.head.repo.pushed_at;
+          if ('${{ inputs.ignore-non-push-updates }}' === 'true') {
+            const prEvents = pushEvents.filter(event => event.payload.ref === 'refs/heads/' + pr.head.ref);
+            lastPushEvent = prEvents.filter(event => event.payload.head === pr.head.sha);
+            if (lastPushEvent.length < 1) {
+                console.log(`No push events found for PR #${pr.number}.`);
+            } else {
+                console.log(`Found ${lastPushEvent.length} push events for PR #${pr.number}.`)
+                lastPushEvent.sort(function(a,b){return new Date(b.created_at) - new Date(a.created_at)});
+                modificationTime = lastPushEvent[0].created_at;
+                console.log(`Using last push event ${modificationTime} for PR #${pr.number}.`);
+            }
           }
           const modificationDate = new Date(modificationTime);
 


### PR DESCRIPTION
This fixes the `ignore-non-push-updates` option introduced in #8. I did not find another way to get the push date of commits other than to look at the `PushEvents` for the repo since `pushedDate` from GraphQL has been removed from the API:
https://github.com/orgs/community/discussions/24730#discussioncomment-3245265
https://docs.github.com/en/graphql/reference/objects#commit
Demo on https://github.com/ngehrsitz/bake-time-test/pull/4 and https://github.com/ngehrsitz/bake-time-test/pull/6